### PR TITLE
BACKPLANE_IGNORE_PROCESS_TYPE

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,6 +4,7 @@ set -e
 
 build=$1
 cache=$2
+CURRENT_PROCESS_TYPE=${DYNO%.*}
 
 mkdir -p $build/bin
 mkdir -p $build/.profile.d
@@ -17,6 +18,24 @@ install_backplane() {
 }
 
 install_backplane
+
+echo "-----> Current process type: $CURRENT_PROCESS_TYPE"
+
+if [ -z ${BACKPLANE_IGNORE_PROCESS_TYPE+x} ]; then
+  echo "-----> Backplane Agent should run on any process type."
+  echo "       Use enviroment variable BACKPLANE_IGNORE_PROCESS_TYPE to ignore process types.";
+  echo "       Example: BACKPLANE_IGNORE_PROCESS_TYPE=run,worker,jobqueue";
+else
+  echo "-----> Backplane Agent should not run on process type: $BACKPLANE_IGNORE_PROCESS_TYPE";
+  IFS=', ' read -r -a array <<< "$BACKPLANE_IGNORE_PROCESS_TYPE"
+  for element in "${array[@]}"
+  do
+    if [ "$element" == "$CURRENT_PROCESS_TYPE" ]; then
+      echo "-----> Skipping start of Backplane Agent!"
+      exit 0
+    fi
+  done
+fi
 
 echo "-----> Writing .profile.d/backplane.sh"
 cat <<-EOF > $build/.profile.d/backplane.sh


### PR DESCRIPTION
Heroku apps can have several process types. Some of them like background jobs should skip the start of the backplane agent.